### PR TITLE
Fix tests to skip without pytest_embedded

### DIFF
--- a/tests/hello_world/test_hello_world.py
+++ b/tests/hello_world/test_hello_world.py
@@ -1,2 +1,7 @@
+import pytest
+
+pytest.importorskip("pytest_embedded")
+
+
 def test_hello_world(dut):
     dut.expect('Hello Arduino!')

--- a/tests/timer/test_timer.py
+++ b/tests/timer/test_timer.py
@@ -1,2 +1,7 @@
+import pytest
+
+pytest.importorskip("pytest_embedded")
+
+
 def test_timer(dut):
     dut.expect_unity_test_output(timeout=240)

--- a/tests/unity/test_unity.py
+++ b/tests/unity/test_unity.py
@@ -1,2 +1,7 @@
+import pytest
+
+pytest.importorskip("pytest_embedded")
+
+
 def test_unity(dut):
     dut.expect_unity_test_output(timeout=240)


### PR DESCRIPTION
## Summary
- allow tests to run without pytest‑embedded by skipping them when fixture is unavailable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ea5091638832597861f42266d0dcd